### PR TITLE
Takahiro/separate er mortality

### DIFF
--- a/sql/MIMIC-IV/06-apache-3.sql
+++ b/sql/MIMIC-IV/06-apache-3.sql
@@ -11,9 +11,23 @@ with
     apache3_missing as (
         select
             'apache3' as field_name,
-            countif(apsiii is null) as n_missing,
-            round(100 * countif(apsiii is null) / count(*), 1) as proportion_missing
+            (select count(distinct stay_id) from `mimiciv_derived.icustay_detail`)
+            - count(distinct stay_id) as n_missing,
+            round(
+                100 * (
+                    (
+                        select count(distinct stay_id)
+                        from `mimiciv_derived.icustay_detail`
+                    )
+                    - count(distinct stay_id)
+                )
+                / (
+                    select count(distinct stay_id) from `mimiciv_derived.icustay_detail`
+                ),
+                1
+            ) as proportion_missing
         from `mimiciv_derived.apsiii`
+        where apsiii is not null
     )
 select field_name, median, percentile_25, percentile_75, n_missing, proportion_missing
 from apache3_stats

--- a/sql/OneICU/05-gender-mortality.sql
+++ b/sql/OneICU/05-gender-mortality.sql
@@ -25,8 +25,6 @@ with
             case
                 when mortality = 'er'
                 then 'ER_death'
-                when mortality is null
-                then 'ER_mortality_unknown'
                 else 'ER_survived'
             end as er_mortality
         from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
@@ -50,8 +48,6 @@ with
             case
                 when mortality = 'icu'
                 then 'ICU_death'
-                when mortality is null
-                then 'ICU_mortality_unknown'
                 else 'ICU_survived'
             end as icu_death,
             case

--- a/sql/OneICU/05-gender-mortality.sql
+++ b/sql/OneICU/05-gender-mortality.sql
@@ -20,37 +20,86 @@ with
             round(100 * count / (select sum(count) from gender_counts), 1) as proportion
         from gender_counts
     ),
-    mortality_stats as (
+    er_mortality_clean as (
         select
             case
                 when mortality = 'er'
                 then 'ER_death'
-                when mortality = 'icu'
-                then 'ICU_death'
-                when mortality = 'in_hospital'
-                then 'In_hospital_death'
                 when mortality is null
-                then 'mortality_unknown'
-                else mortality
-            end as mortality
+                then 'ER_mortality_unknown'
+                else 'ER_survived'
+            end as er_mortality
         from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
     ),
-    mortality_counts as (
-        select mortality as field_name, count(*) as count
-        from mortality_stats
-        group by mortality
+    er_mortality_counts as (
+        select er_mortality as field_name, count(*) as count
+        from er_mortality_clean
+        group by er_mortality
     ),
-    mortality_proportions as (
+    er_mortality_proportions as (
         select
             field_name,
             count,
             round(
-                100 * count / (select sum(count) from mortality_counts), 1
+                100 * count / (select sum(count) from er_mortality_counts), 1
             ) as proportion
-        from mortality_counts
+        from er_mortality_counts
+    ),
+    mortality_clean as (
+        select
+            case
+                when mortality = 'icu'
+                then 'ICU_death'
+                when mortality is null
+                then 'ICU_mortality_unknown'
+                else 'ICU_survived'
+            end as icu_death,
+            case
+                when mortality in ('icu', 'in_hospital')
+                then 'In_hospital_death'
+                when mortality is null
+                then 'In_hospital_mortality_unknown'
+                else 'In_hospital_survived'
+            end as in_hospital_death
+        from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
+        where mortality is null or mortality != 'er'
+    ),
+    icu_mortality_counts as (
+        select icu_death as field_name, count(*) as count
+        from mortality_clean
+        group by icu_death
+    ),
+    icu_mortality_proportions as (
+        select
+            field_name,
+            count,
+            round(
+                100 * count / (select sum(count) from icu_mortality_counts), 1
+            ) as proportion
+        from icu_mortality_counts
+    ),
+    in_hospital_mortality_counts as (
+        select in_hospital_death as field_name, count(*) as count
+        from mortality_clean
+        group by in_hospital_death
+    ),
+    in_hospital_mortality_proportions as (
+        select
+            field_name,
+            count,
+            round(
+                100 * count / (select sum(count) from in_hospital_mortality_counts), 1
+            ) as proportion
+        from in_hospital_mortality_counts
     )
 select *
 from gender_proportions
 union all
 select *
-from mortality_proportions
+from er_mortality_proportions
+union all
+select *
+from icu_mortality_proportions
+union all
+select *
+from in_hospital_mortality_proportions

--- a/sql/OneICU/06-apache-2-and-3.sql
+++ b/sql/OneICU/06-apache-2-and-3.sql
@@ -11,11 +11,27 @@ with
     apache2_missing as (
         select
             'apache2_score' as field_name,
-            countif(apache2_score is null) as n_missing,
+            (
+                select count(distinct icu_stay_id)
+                from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
+            )
+            - count(distinct icu_stay_id) as n_missing,
             round(
-                100 * countif(apache2_score is null) / count(*), 1
+                100 * (
+                    (
+                        select count(distinct icu_stay_id)
+                        from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
+                    )
+                    - count(distinct icu_stay_id)
+                )
+                / (
+                    select count(distinct icu_stay_id)
+                    from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
+                ),
+                1
             ) as proportion_missing
         from `medicu-beta.latest_one_icu_derived.apache2`
+        where apache2_score is not null
     ),
     apache3_stats as (
         select distinct
@@ -29,11 +45,27 @@ with
     apache3_missing as (
         select
             'apache3_score' as field_name,
-            countif(apache3_score is null) as n_missing,
+            (
+                select count(distinct icu_stay_id)
+                from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
+            )
+            - count(distinct icu_stay_id) as n_missing,
             round(
-                100 * countif(apache3_score is null) / count(*), 1
+                100 * (
+                    (
+                        select count(distinct icu_stay_id)
+                        from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
+                    )
+                    - count(distinct icu_stay_id)
+                )
+                / (
+                    select count(distinct icu_stay_id)
+                    from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
+                ),
+                1
             ) as proportion_missing
         from `medicu-beta.latest_one_icu_derived.apache3`
+        where apache3_score is not null
     )
 select field_name, median, percentile_25, percentile_75, n_missing, proportion_missing
 from apache2_stats

--- a/sql/OneICU/07-sofa-first-day.sql
+++ b/sql/OneICU/07-sofa-first-day.sql
@@ -7,10 +7,43 @@ with
             and time_window_index >= 0
             and time_window_index < 24
         group by icu_stay_id
+    ),
+    sofa_stats as (
+        select distinct
+            'sofa' as field_name,
+            percentile_cont(sofa, 0.5) over () as median,
+            percentile_cont(sofa, 0.25) over () as percentile_25,
+            percentile_cont(sofa, 0.75) over () as percentile_75
+        from first_day_sofa_per_patients
+    ),
+    sofa_missing as (
+        select
+            'sofa' as field_name,
+            (
+                select count(distinct icu_stay_id)
+                from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
+            )
+            - count(distinct icu_stay_id) as n_missing,
+            round(
+                100 * (
+                    (
+                        select count(distinct icu_stay_id)
+                        from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
+                    )
+                    - count(distinct icu_stay_id)
+                )
+                / (
+                    select count(distinct icu_stay_id)
+                    from `medicu-beta.latest_one_icu_derived.extended_icu_stays`
+                ),
+                1
+            ) as proportion_missing
+        from `medicu-beta.latest_one_icu_derived.sofa_hourly`
+        where
+            sofa_24hours is not null
+            and time_window_index >= 0
+            and time_window_index < 24
     )
-select distinct
-    'sofa' as field_name,
-    percentile_cont(sofa, 0.5) over () as median,
-    percentile_cont(sofa, 0.25) over () as percentile_25,
-    percentile_cont(sofa, 0.75) over () as percentile_75
-from first_day_sofa_per_patients
+select field_name, median, percentile_25, percentile_75, n_missing, proportion_missing
+from sofa_stats
+inner join sofa_missing using (field_name)


### PR DESCRIPTION
## WHY
Align the definition of ICU mortality with MIMIC and eICU by excluding patients who died in the ER
## WHAT
Separate the patients who died in the ER